### PR TITLE
Update the API version for PerformanceProfile

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -118,7 +118,7 @@ In This definition, note that:
 
 ::
 
-   apiVersion: performance.openshift.io/v1alpha1
+   apiVersion: performance.openshift.io/v2
    kind: PerformanceProfile
    metadata:
      name: worker-cnf


### PR DESCRIPTION
PAO operator has a v2 API, no changes are needed to the manifest. PAO documentation for 4.8 and 4.9 references the v2 API